### PR TITLE
docs: fix paths and name of bridge smart contract

### DIFF
--- a/BRIDGE.md
+++ b/BRIDGE.md
@@ -3,16 +3,16 @@
 
 This project is a truffle project. There are multiple files in the contracts folder and you can select between:
 
-- [`MyNFTBridge.sol`](Codebase/Bridge_Contracts/contracts/MyNFTBridge.sol): This is the base bridge interface.
+- [`Bridge.sol`](Codebase/Bridge_Contracts/contracts/Bridge.sol): This is the base bridge interface.
 `Implementation`
 - [`/Implementation/ERC721.sol`](Codebase/Bridge_Contracts/contracts/Implementation/ERC721.sol): This is the base ERC-721 token interface.
 
 `/Implementation/BridgeFeatures/` folder contains the different functions of the bridge.
 The bridge implements the ERC-1538 proxy pattern in order to be upgradable:
-- [`ImplBridgeFunMigrateFromERC721.sol`](Codebase/Bridge_Contracts/contracts/ImplBridgeFunMigrateFromERC721.sol): This implements logic data of the arrival bridge (IOU minting / transfert / ...).
-- [`ImplERC721TokenReceiver.sol`](Codebase/Bridge_Contracts/contracts/ImplERC721TokenReceiver.sol): Handle the receipt of an NFT, the ERC721 smart contract calls this function on the recipient after a `transfer`.
-- [`ImplMyNFTBridgeFunInit.sol`](Codebase/Bridge_Contracts/contracts/ImplMyNFTBridgeFunInit.sol): This implements logic data of a bridge initialization.
-- [`ImplMyNFTBridgeFunMigrateToERC721.sol`](Codebase/Bridge_Contracts/contracts/ImplMyNFTBridgeFunMigrateToERC721.sol): This implements logic data of the departure bridge (migration intent / escrow and signature hash generation)
+- [`ImplBridgeFunMigrateFromERC721.sol`](Codebase/Bridge_Contracts/contracts/Implementation/BridgeFeatures/ImplBridgeFunMigrateFromERC721.sol): This implements logic data of the arrival bridge (IOU minting / transfert / ...).
+- [`ImplERC721TokenReceiver.sol`](Codebase/Bridge_Contracts/contracts/Implementation/BridgeFeatures/ImplERC721TokenReceiver.sol): Handle the receipt of an NFT, the ERC721 smart contract calls this function on the recipient after a `transfer`.
+- [`ImplBridgeFunInit.sol`](Codebase/Bridge_Contracts/contracts/Implementation/BridgeFeatures/ImplBridgeFunInit.sol): This implements logic data of a bridge initialization.
+- [`ImplBridgeFunMigrateToERC721.sol`](Codebase/Bridge_Contracts/contracts/Implementation/BridgeFeatures/ImplBridgeFunMigrateToERC721.sol): This implements logic data of the departure bridge (migration intent / escrow and signature hash generation)
 
 `/Implementation/Proxification/` folder contains the different functions of the ERC-1538 proxy pattern for Bridge deployment. Get more infos [here](https://eips.ethereum.org/EIPS/eip-1538)
 


### PR DESCRIPTION
Small update in the documentation 